### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ The agent has a planning mode for generating an initial plan for your app.
 
 This MCP server is for doing doing initial app planning and creating a good starting point for an app.
 
+<a href="https://glama.ai/mcp/servers/wfr9djhfnu">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/wfr9djhfnu/badge" alt="Databutton Server MCP server" />
+</a>
+
 ## Development
 
 Install dependencies:
@@ -30,7 +34,7 @@ npm run watch
 
 To use with Claude Desktop, add the server config:
 
-On MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+On MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`  
 On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 
 ```json


### PR DESCRIPTION
This PR adds a badge for the [Databutton MCP Server](https://glama.ai/mcp/servers/wfr9djhfnu) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/wfr9djhfnu">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/wfr9djhfnu/badge" alt="Databutton Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.